### PR TITLE
EAS-481 Initial check-in of module to log queryable json CloudWatch

### DIFF
--- a/emergency_alerts_utils/structured_logging.py
+++ b/emergency_alerts_utils/structured_logging.py
@@ -42,7 +42,7 @@ class UUIDEncoder(json.JSONEncoder):
 def log_to_cloudwatch(logData: LogData):
     try:
         b3client.put_log_events(
-            logGroupName='LOG_GROUP_NAME',
+            logGroupName=os.environ.get('LOG_GROUP_NAME'),
             logStreamName=os.environ.get('HOSTNAME'),
             logEvents=[
                 {

--- a/emergency_alerts_utils/structured_logging.py
+++ b/emergency_alerts_utils/structured_logging.py
@@ -1,0 +1,24 @@
+import json
+
+from dataclasses import dataclass, asdict
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class LogData():
+    source: str
+    module: str
+    method: str
+    serviceId: UUID
+    broadcastMessageId: UUID
+
+    def __str__(self) -> str:
+        return json.dumps(asdict(self), cls=UUIDEncoder)
+
+
+class UUIDEncoder(json.JSONEncoder):
+    # Solution to the runtime error: [TypeError: Object of type UUID is not JSON serializable]
+    def default(self, obj):
+        if isinstance(obj, UUID):
+            return str(obj)
+        return json.JSONEncoder.default(self, obj)

--- a/emergency_alerts_utils/structured_logging.py
+++ b/emergency_alerts_utils/structured_logging.py
@@ -42,7 +42,7 @@ class UUIDEncoder(json.JSONEncoder):
 def log_to_cloudwatch(logData: LogData):
     try:
         b3client.put_log_events(
-            logGroupName='/ecs/eas-app-api-container',
+            logGroupName='LOG_GROUP_NAME',
             logStreamName=os.environ.get('HOSTNAME'),
             logEvents=[
                 {

--- a/emergency_alerts_utils/structured_logging.py
+++ b/emergency_alerts_utils/structured_logging.py
@@ -12,7 +12,7 @@ from uuid import UUID
 b3client = boto3.client("logs", region_name=os.environ.get('AWS_REGION'))
 try:
     b3client.create_log_stream(
-        logGroupName='/ecs/eas-app-api-container',
+        logGroupName=os.environ.get('LOG_GROUP_NAME'),
         logStreamName=os.environ.get('HOSTNAME')
     )
 except ClientError as e:


### PR DESCRIPTION
Add LogData DataClass to give some structure to the data written out to CloudWatch
- Writing json to CloudWatch allows the data to be queried
- The LogData class suggests required fields

Note: This is a starting point only and is not complete