### PR TITLE
EAS-447 Add default region and refactor dockerfile for fewer layers

### DIFF
--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -13,41 +13,35 @@ ENV NVM_VERSION='v0.39.1'
 ENV VENV_UTILS=/venv/eas-utils
 ENV UTILS_DIR=/eas/emergency-alerts-utils
 
-# Copy the bashrc file and replace existing.
+# Copy the bashrc file and remove command that exits bashrc file if not running interactively.
 RUN mv $SHELL_CONF $SHELL_CONF.bak; cat $SHELL_CONF.bak | sed 's/\[ -z "$PS1" \] && return//' > $SHELL_CONF;
 
 # Update OS to latest.
 RUN apt-get update -y
 
-# Install commonly used tools
-RUN apt-get install wget curl git unzip vim make systemctl jq apt-utils telnet dnsutils build-essential -y
-
-# Common installs some ca-certs and python related pre-reqs.
-RUN apt-get install ca-certificates -y
+# Install commonly used tools, python related pre-reqs and ca-certs
+RUN apt-get install wget curl git unzip vim make systemctl jq apt-utils telnet dnsutils build-essential \
+    ca-certificates libcurl4-openssl-dev libssl-dev -y --no-install-recommends
 
 # Download the database certificate
-RUN wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /etc/ssl/certs/global-bundle.pem
-RUN update-ca-certificates
-
-# Install OpenSSL libs.
-RUN apt-get install libcurl4-openssl-dev libssl-dev -y
+RUN wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /etc/ssl/certs/global-bundle.pem && \
+    update-ca-certificates
 
 # Install Python and VENV.
-RUN apt-get install $PYTHON_VERSION $PYTHON_VERSION-venv python3-pip libpython3.9-dev -y && mkdir $VENV_ROOT
+RUN apt-get install $PYTHON_VERSION $PYTHON_VERSION-venv python3-pip libpython3.9-dev -y --no-install-recommends && \
+    mkdir $VENV_ROOT
 
 # Install AWS CLI
-RUN curl 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o 'awscliv2.zip'; unzip 'awscliv2.zip' && ./aws/install;
+RUN curl 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o 'awscliv2.zip'; unzip 'awscliv2.zip' && \
+    ./aws/install;
 
 # Install Node JS with NVM.
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh | bash
 
 # Validate the installation
-RUN . $SHELL_CONF && nvm install $NODE_VERSION && nvm use $NODE_VERSION  || echo 'Could not find node version';
-
-# Validating node installation
-RUN . $SHELL_CONF && node --version
+RUN . $SHELL_CONF && nvm install $NODE_VERSION && nvm use $NODE_VERSION && \
+    node --version || echo 'Could not find node version';
 
 # Build emergency-alerts-utils
 COPY . $UTILS_DIR
-RUN $PYTHON_VERSION -m venv $VENV_UTILS
-RUN cd $UTILS_DIR && . $VENV_UTILS/bin/activate && make bootstrap
+RUN $PYTHON_VERSION -m venv $VENV_UTILS && cd $UTILS_DIR && . $VENV_UTILS/bin/activate && make bootstrap

--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -20,8 +20,7 @@ RUN mv $SHELL_CONF $SHELL_CONF.bak; cat $SHELL_CONF.bak | sed 's/\[ -z "$PS1" \]
 RUN apt-get update -y
 
 # Install commonly used tools, python related pre-reqs and ca-certs
-RUN apt-get install wget curl git unzip vim make systemctl jq apt-utils telnet dnsutils build-essential \
-    ca-certificates libcurl4-openssl-dev libssl-dev -y --no-install-recommends
+RUN apt-get install wget curl git unzip vim make systemctl jq apt-utils telnet dnsutils build-essential ca-certificates libcurl4-openssl-dev libssl-dev -y --no-install-recommends
 
 # Download the database certificate
 RUN wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /etc/ssl/certs/global-bundle.pem && \

--- a/emergency_alerts_utils/structured_logging.py
+++ b/emergency_alerts_utils/structured_logging.py
@@ -7,7 +7,7 @@ from botocore.exceptions import ClientError
 from uuid import UUID
 
 
-b3client = boto3.client("logs", region_name=os.environ.get('AWS_REGION'))
+b3client = boto3.client("logs", region_name=os.environ.get('AWS_REGION', "eu-west-2"))
 try:
     b3client.create_log_stream(
         logGroupName=os.environ.get('LOG_GROUP_NAME'),


### PR DESCRIPTION
As another step toward self-contained Fargate deployed microservices, the following changes have been made to the Emergency Alerts Utils repo:

- Empty default region when fetching from environment is causing test failure in emergency-alerts-api repo.
- Dockerfile has been refactored to have fewer layers
