### PR TITLE
Bump major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 60.0.0
+
+* Re-named package (emergency-alerts-utils) now considered stable
+
 ## 60.0.0-alpha
 
 * Package name change to follow repository name change (notifications-utils -> emergency-alerts-utils)

--- a/emergency_alerts_utils/version.py
+++ b/emergency_alerts_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "59.3.0"  # 9a88d4e7655fc7856a9729df319308cd
+__version__ = "60.0.0"  # d5e77ae80ef5e55a49019d7bf891fe5a


### PR DESCRIPTION
Package considered stable after name change (from notifications-utils to emergency-alerts-utils)