### PR TITLE
EAS-447 More changes to prepare for pipeline builds

### DIFF
--- a/emergency_alerts_utils/structured_logging.py
+++ b/emergency_alerts_utils/structured_logging.py
@@ -5,10 +5,8 @@ from uuid import UUID
 
 import boto3
 from botocore.exceptions import ClientError
-from moto import mock_logs
 
 
-@mock_logs
 class LogData:
     b3client = None
     logGroupName = ""

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -28,6 +28,7 @@ function docker_build(){
     --platform $PLATFORM \
     -t $ECS_ACCOUNT_NUMBER.dkr.ecr.$REGION.amazonaws.com/eas-app-$IMAGE:latest \
     -f Dockerfile.eas-$IMAGE \
+    --no-cache \
     $ARGS \
     .
 }


### PR DESCRIPTION
Further changes to support CI/CD pipeline:

- Remove incorrect 'moto' mocking decorator
- Add --no-cache flag to buildx command to ensure the freshest dependencies are used to build the images