### PR TITLE
EAS-880 Add upgrade step for pip, wheels and setuptools

### DIFF
--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -39,4 +39,5 @@ RUN . $SHELL_CONF && nvm install $NODE_VERSION && nvm use $NODE_VERSION && \
 
 # Build emergency-alerts-utils
 COPY . $UTILS_DIR
-RUN $PYTHON_VERSION -m venv $VENV_UTILS && cd $UTILS_DIR && . $VENV_UTILS/bin/activate && make bootstrap
+WORKDIR $UTILS_DIR
+RUN $PYTHON_VERSION -m venv $VENV_UTILS && . $VENV_UTILS/bin/activate && $PYTHON_VERSION -m pip install --upgrade pip wheel setuptools && make bootstrap


### PR DESCRIPTION
The codebuild pipeline was failing due to errors with wheels and other tooling being out of date. Adding a separate upgrade step for the pip, wheels and setuptools packages fixed the issue.