### PR TITLE
Change makefile command to use pip3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 
 .PHONY: bootstrap
 bootstrap: ## Build project
-	pip install -r requirements_for_test.txt
+	pip3 install -r requirements_for_test.txt
 
 .PHONY: test
 test: ## Run tests


### PR DESCRIPTION
To avoid version ambiguity, use pip3 in the Makefile