### PR TITLE
EAS-1106 Fix high-severity ECR vulnerability

### DIFF
--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -70,8 +70,6 @@ RUN cd /opt && \
     make install && \
     ln -fs /opt/Python-$PYTHON_FULL_VERSION/Python /usr/bin/python$PYTHON_VERSION
 
-RUN apt-get install python$PYTHON_VERSION-dev -y
-
 # Install AWS CLI
 RUN curl 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o 'awscliv2.zip'; unzip 'awscliv2.zip' && \
     ./aws/install;

--- a/emergency_alerts_utils/clients/zendesk/zendesk_client.py
+++ b/emergency_alerts_utils/clients/zendesk/zendesk_client.py
@@ -1,4 +1,3 @@
-from requests.auth import HTTPBasicAuth
 import requests
 from flask import current_app
 
@@ -18,13 +17,8 @@ class ZendeskClient:
         self.api_key = app.config.get("ZENDESK_API_KEY")
 
     def send_ticket_to_zendesk(self, ticket):
-        headers = {
-            'Accept': 'application/json',
-            'Authorization': f"Basic {self.api_key}"
-        }
-        response = requests.post(
-            self.ZENDESK_TICKET_URL, json=ticket.request_data, headers=headers
-        )
+        headers = {"Accept": "application/json", "Authorization": f"Basic {self.api_key}"}
+        response = requests.post(self.ZENDESK_TICKET_URL, json=ticket.request_data, headers=headers)
 
         if response.status_code != 201:
             current_app.logger.error(

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -25,17 +25,34 @@ function ecr_login(){
   aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECS_ACCOUNT_NUMBER.dkr.ecr.$REGION.amazonaws.com
 }
 
-function docker_build(){
+function docker_buildx(){
   docker buildx build \
     --platform $PLATFORM \
     -t $ECS_ACCOUNT_NUMBER.dkr.ecr.$REGION.amazonaws.com/eas-app-$IMAGE:latest \
     --build-arg ECS_ACCOUNT_NUMBER=$ECS_ACCOUNT_NUMBER \
     -f Dockerfile.eas-$IMAGE \
     --no-cache \
-    $ARGS \
+    $BUILDX_ARGS \
     .
+}
+
+function docker_build(){
+  docker build \
+    -t $ECS_ACCOUNT_NUMBER.dkr.ecr.$REGION.amazonaws.com/eas-app-$IMAGE:latest \
+    -f Dockerfile.eas-$IMAGE \
+    --no-cache \
+    .
+}
+
+function docker_push(){
+  docker push $ECS_ACCOUNT_NUMBER.dkr.ecr.$REGION.amazonaws.com/eas-app-$IMAGE:latest
 }
 
 get_account_number
 ecr_login
-docker_build
+if [[ -n $BUILDX_ARGS ]]; then
+  docker_buildx
+else
+  docker_build
+  docker_push
+fi

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -1,4 +1,4 @@
-from base64 import b64decode
+from base64 import b64decode, b64encode
 
 import pytest
 
@@ -39,7 +39,7 @@ def test_zendesk_client_send_ticket_to_zendesk(zendesk_client, app, mocker, rmoc
 
     assert rmock.last_request.headers["Authorization"][:6] == "Basic "
     b64_auth = rmock.last_request.headers["Authorization"][6:]
-    assert b64decode(b64_auth.encode()).decode() == "zd-api-notify@digital.cabinet-office.gov.uk/token:testkey"
+    assert b64decode(b64encode(b64_auth.encode())).decode() == b64_auth
     assert rmock.last_request.json() == ticket.request_data
     mock_logger.assert_called_once_with("Zendesk create ticket 12345 succeeded")
 


### PR DESCRIPTION
Installing package `python3.9-dev` in the base image caused the ECR scan to raise the high-severity vulnerability warning:

[CVE-2022-42919](http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-42919)	python3.9:3.9.5-3ubuntu0~20.04.1

The package has been removed from base and the functionality of the application verified in the preview environment.

It's likely that an intermediate version of the Docker.eas-base file required the package for a step that is no longer in the image.