### PR TITLE
EAS-1576 Fix 'development' config

### DIFF
--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -12,7 +12,7 @@ ENV NODE_VERSION='v16.14.0'
 ENV NVM_VERSION='v0.39.1'
 ENV FLASK_APP='application.py'
 ENV NOTIFY_LOG_PATH='/var/log/notify.log'
-ENV HOST='decoupled'
+ENV HOST='hosted'
 
 # Virtual Envs
 ENV VENV_UTILS='/venv/emergency-alerts-utils'

--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -12,7 +12,7 @@ ENV NODE_VERSION='v16.14.0'
 ENV NVM_VERSION='v0.39.1'
 ENV FLASK_APP='application.py'
 ENV NOTIFY_LOG_PATH='/var/log/notify.log'
-ENV NOTIFY_ENVIRONMENT='decoupled'
+ENV HOST='decoupled'
 
 # Virtual Envs
 ENV VENV_UTILS='/venv/emergency-alerts-utils'

--- a/emergency_alerts_utils/clients/statsd/statsd_client.py
+++ b/emergency_alerts_utils/clients/statsd/statsd_client.py
@@ -51,7 +51,7 @@ class StatsdClient:
     def init_app(self, app, *args, **kwargs):
         app.statsd_client = self
         self.active = app.config.get("STATSD_ENABLED")
-        self.namespace = f"{app.config.get('NOTIFY_ENVIRONMENT')}.notifications.{app.config.get('NOTIFY_APP_NAME')}."
+        self.namespace = f"{app.config.get('HOST')}.notifications.{app.config.get('NOTIFY_APP_NAME')}."
 
         if self.active:
             self.statsd_client = NotifyStatsClient(

--- a/tests/clients/statsd/test_statsd_client.py
+++ b/tests/clients/statsd/test_statsd_client.py
@@ -23,7 +23,7 @@ def disabled_statsd_client(app, mocker):
 
 def build_statsd_client(app, mocker):
     client = StatsdClient()
-    app.config["NOTIFY_ENVIRONMENT"] = "test"
+    app.config["HOST"] = "test"
     app.config["NOTIFY_APP_NAME"] = "api"
     app.config["STATSD_HOST"] = "localhost"
     app.config["STATSD_PORT"] = "8000"

--- a/tests/test_statsd_decorators.py
+++ b/tests/test_statsd_decorators.py
@@ -9,7 +9,7 @@ class AnyStringWith(str):
 
 
 def test_should_call_statsd(app, mocker):
-    app.config["NOTIFY_ENVIRONMENT"] = "test"
+    app.config["HOST"] = "test"
     app.config["NOTIFY_APP_NAME"] = "api"
     app.config["STATSD_HOST"] = "localhost"
     app.config["STATSD_PORT"] = "8000"


### PR DESCRIPTION
To switch between local and hosted environments, the NOTIFY_ENVIRONMENT variable has been renamed to HOST.

The NOTIFY_ENVIRONMENT variable can take one of two values:
- HOST = [ local  |  hosted ]

The ENVIRONMENT variable can now take one of the following values:
- ENVIRONMENT = [ local  |  development  |  preview  |  staging  |  production ]

The development environment hosted on AWS will now configure the above variables as follows:
HOST=hosted  &  ENVIRONMENT=development