### PR TITLE
Changing where the encryption library gets it's SALT and SECRET from

### DIFF
--- a/emergency_alerts_utils/clients/encryption/encryption_client.py
+++ b/emergency_alerts_utils/clients/encryption/encryption_client.py
@@ -3,8 +3,8 @@ from itsdangerous import URLSafeSerializer
 
 class Encryption:
     def init_app(self, app):
-        self.serializer = URLSafeSerializer(app.config.get("SECRET_KEY"))
-        self.salt = app.config.get("DANGEROUS_SALT")
+        self.serializer = URLSafeSerializer(app.config.get("ENCRYPTION_SECRET_KEY"))
+        self.salt = app.config.get("ENCRYPTION_DANGEROUS_SALT")
 
     def encrypt(self, thing_to_encrypt):
         return self.serializer.dumps(thing_to_encrypt, salt=self.salt)

--- a/tests/clients/encryption/test_encryption_client.py
+++ b/tests/clients/encryption/test_encryption_client.py
@@ -7,8 +7,8 @@ from emergency_alerts_utils.clients.encryption.encryption_client import Encrypti
 def encryption_client(app):
     client = Encryption()
 
-    app.config["SECRET_KEY"] = "test-notify-secret-key"
-    app.config["DANGEROUS_SALT"] = "test-notify-salt"
+    app.config["ENCRYPTION_SECRET_KEY"] = "test-notify-secret-key"
+    app.config["ENCRYPTION_DANGEROUS_SALT"] = "test-notify-salt"
 
     client.init_app(app)
 


### PR DESCRIPTION


---

🚨⚠️ PLEASE NOTE ⚠️🚨

When merging changes in the utils repository, the base image will need to be rebuilt, and then every other AMI after that.
This is to identify any issues that may crop up from making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of any potential issues that show up later.
