### PR TITLE
EAS-2447 Add variable for max alert char count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ read-source-file: write-source-file
 	echo '. "$$NVM_DIR/nvm.sh"' >> ~/.nvm-source;
 
 	@if [[ "$(NVM_DIR)" == "" || ! -f "$(NVM_DIR)/nvm.sh" ]]; then \
+		mkdir -p $(HOME)/.nvm; \
+		export NVM_DIR=$(HOME)/.nvm; \
 		curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$(NVM_VERSION)/install.sh | bash; \
 		echo ""; \
 		$(MAKE) write-source-file; \

--- a/emergency_alerts_utils/__init__.py
+++ b/emergency_alerts_utils/__init__.py
@@ -2,6 +2,7 @@ import re
 
 SMS_CHAR_COUNT_LIMIT = 918  # 153 * 6, no network issues but check with providers before upping this further
 LETTER_MAX_PAGE_COUNT = 10
+MAX_BROADCAST_CHAR_COUNT = 1395
 
 # regexes for use in recipients.validate_email_address.
 # Valid characters taken from https://en.wikipedia.org/wiki/Email_address#Local-part

--- a/emergency_alerts_utils/template.py
+++ b/emergency_alerts_utils/template.py
@@ -8,11 +8,7 @@ from os import path
 from jinja2 import Environment, FileSystemLoader
 from markupsafe import Markup
 
-from emergency_alerts_utils import (
-    LETTER_MAX_PAGE_COUNT,
-    MAGIC_SEQUENCE,
-    SMS_CHAR_COUNT_LIMIT,
-)
+from emergency_alerts_utils import MAGIC_SEQUENCE, MAX_BROADCAST_CHAR_COUNT
 from emergency_alerts_utils.countries.data import Postage
 from emergency_alerts_utils.field import Field, PlainTextField
 from emergency_alerts_utils.formatters import (
@@ -248,7 +244,7 @@ class BaseSMSTemplate(Template):
         send messages well over our limit. There were some inconsistencies with how we were validating the
         length of a message. This should be the method used anytime we want to reject a message for being too long.
         """
-        return self.content_count_without_prefix > SMS_CHAR_COUNT_LIMIT
+        return self.content_count_without_prefix > MAX_BROADCAST_CHAR_COUNT
 
     def is_message_empty(self):
         return self.content_count_without_prefix == 0
@@ -815,7 +811,7 @@ class LetterImageTemplate(BaseLetterTemplate):
 
     @property
     def last_page_number(self):
-        return min(self.page_count, LETTER_MAX_PAGE_COUNT) + self.first_page_number
+        return min(self.page_count, MAX_BROADCAST_CHAR_COUNT) + self.first_page_number
 
     @property
     def page_numbers(self):

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -11,6 +11,7 @@ from freezegun import freeze_time
 from markupsafe import Markup
 from orderedset import OrderedSet
 
+from emergency_alerts_utils import MAX_BROADCAST_CHAR_COUNT
 from emergency_alerts_utils.formatters import unlink_govuk_escaped
 from emergency_alerts_utils.template import (
     BaseBroadcastTemplate,
@@ -2809,15 +2810,15 @@ def test_broadcast_message_from_event():
     "content, expected_non_gsm, expected_max, expected_too_long",
     (
         (
-            "a" * 1395,
+            "a" * MAX_BROADCAST_CHAR_COUNT,
             set(),
-            1395,
+            MAX_BROADCAST_CHAR_COUNT,
             False,
         ),
         (
-            "a" * 1396,
+            "a" * (MAX_BROADCAST_CHAR_COUNT + 1),
             set(),
-            1395,
+            MAX_BROADCAST_CHAR_COUNT,
             True,
         ),
         (
@@ -2834,15 +2835,15 @@ def test_broadcast_message_from_event():
             True,
         ),
         (
-            "[" * 697,  # Half of 1395, rounded down
+            "[" * 697,  # Half of 1395 (MAX_BROADCAST_CHAR_COUNT), rounded down
             set(),
-            1395,
+            MAX_BROADCAST_CHAR_COUNT,
             False,
         ),
         (
-            "[" * 698,  # Half of 1395, rounded up
+            "[" * 698,  # Half of 1395 (MAX_BROADCAST_CHAR_COUNT), rounded up
             set(),
-            1395,
+            MAX_BROADCAST_CHAR_COUNT,
             True,
         ),
         (


### PR DESCRIPTION
Max broadcast char count is hardcoded throughout the api/admin repos. Add here to avoid hardcoding.

---

🚨⚠️ PLEASE NOTE ⚠️🚨

When merging changes in the utils repository, the base image will need to be rebuilt, and then every other AMI after that.
This is to identify any issues that may crop up from making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of any potential issues that show up later.
