### PR TITLE
Changed how JsonFormatter referenced in imports

### DIFF
--- a/emergency_alerts_utils/logging.py
+++ b/emergency_alerts_utils/logging.py
@@ -4,7 +4,7 @@ import sys
 
 from flask import g, request
 from flask.ctx import has_app_context, has_request_context
-from pythonjsonlogger.jsonlogger import JsonFormatter
+from pythonjsonlogger.json import JsonFormatter
 
 
 def init_app(app, statsd_client=None):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "cachetools>=4.1.1",
         "mistune<2.0.0",  # v2 is totally incompatible with unclear benefit
         "requests>=2.25.0",
-        "python-json-logger>=2.0.1",
+        "python-json-logger>=3.2.0",
         "Flask>=3.0.2",
         "orderedset>=2.0.3",
         "Jinja2>=2.11.3",


### PR DESCRIPTION
This PR consists of:
- Updated version of python-json-logger
- Adjustment to where JsonFormatter imported from

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
