### PR TITLE
EAS-2569: Add constants for admin approvals

### DIFF
--- a/emergency_alerts_utils/admin_action.py
+++ b/emergency_alerts_utils/admin_action.py
@@ -12,11 +12,13 @@ ADMIN_ACTION_LIST = [
 ADMIN_STATUS_PENDING = "pending"
 ADMIN_STATUS_APPROVED = "approved"
 ADMIN_STATUS_REJECTED = "rejected"
+ADMIN_STATUS_INVALIDATED = "invalidated"
 
 ADMIN_STATUS_LIST = [
     ADMIN_STATUS_PENDING,
     ADMIN_STATUS_APPROVED,
     ADMIN_STATUS_REJECTED,
+    ADMIN_STATUS_INVALIDATED,
 ]
 
 # Permissions which require approval from an additional admin before being added

--- a/emergency_alerts_utils/admin_action.py
+++ b/emergency_alerts_utils/admin_action.py
@@ -1,0 +1,23 @@
+# Tasks which require another platform admin to approve before being actioned
+ADMIN_INVITE_USER = "invite_user"
+ADMIN_EDIT_PERMISSIONS = "edit_permissions"  # Only if adding permissions, removal does not need approval
+ADMIN_CREATE_API_KEY = "create_api_key"
+
+ADMIN_ACTION_LIST = [
+    ADMIN_INVITE_USER,
+    ADMIN_EDIT_PERMISSIONS,
+    ADMIN_CREATE_API_KEY,
+]
+
+ADMIN_STATUS_PENDING = "pending"
+ADMIN_STATUS_APPROVED = "approved"
+ADMIN_STATUS_REJECTED = "rejected"
+
+ADMIN_STATUS_LIST = [
+    ADMIN_STATUS_PENDING,
+    ADMIN_STATUS_APPROVED,
+    ADMIN_STATUS_REJECTED,
+]
+
+# Permissions which require approval from an additional admin before being added
+ADMIN_SENSITIVE_PERMISSIONS = ["create_broadcasts", "approve_broadcasts"]

--- a/emergency_alerts_utils/api_key.py
+++ b/emergency_alerts_utils/api_key.py
@@ -1,0 +1,15 @@
+KEY_TYPE_NORMAL = "normal"
+KEY_TYPE_TEAM = "team"
+KEY_TYPE_TEST = "test"
+
+KEY_TYPE_DESCRIPTIONS = {
+    KEY_TYPE_NORMAL: "Live – sends to anyone",
+    KEY_TYPE_TEAM: "Team and guest list – limits who you can send to",
+    KEY_TYPE_TEST: "Test – pretends to send messages",
+}
+
+KEY_TYPES = [
+    KEY_TYPE_NORMAL,
+    KEY_TYPE_TEAM,
+    KEY_TYPE_TEST,
+]


### PR DESCRIPTION
For future changes in https://github.com/alphagov/emergency-alerts-api/pull/190 and https://github.com/alphagov/emergency-alerts-admin/pull/220 we can centralise these small constants.

I'm assuming this will need to be merged before future runs in the other repositories can pick this up.