### PR TITLE
Remove checkout to tag in Buildspec

### DIFF
--- a/.codepipeline/buildspec-base-build.yml
+++ b/.codepipeline/buildspec-base-build.yml
@@ -3,11 +3,6 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - |
-        if [ -n "$MANUAL_PIPELINE_BRANCH" ]; then
-          echo Manual pipeline branch provided, checking out branch $MANUAL_PIPELINE_BRANCH
-          git checkout $MANUAL_PIPELINE_BRANCH
-        fi
       - echo Logging in to Amazon ECR...
       - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS
         --password-stdin $ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com

--- a/.codepipeline/buildspec-base-build.yml
+++ b/.codepipeline/buildspec-base-build.yml
@@ -4,9 +4,9 @@ phases:
   pre_build:
     commands:
       - |
-        if [ -n "$COMMIT_ID" ]; then
-          echo Checking out to utils_${ENVIRONMENT}_latest tag...
-          git checkout tags/utils_${ENVIRONMENT}_latest
+        if [ -n "$MANUAL_PIPELINE_BRANCH" ]; then
+          echo Manual pipeline branch provided, checking out branch $MANUAL_PIPELINE_BRANCH
+          git checkout $MANUAL_PIPELINE_BRANCH
         fi
       - echo Logging in to Amazon ECR...
       - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS


### PR DESCRIPTION
This PR removes the tag checkout in the `buildspec.yml`. It has been agreed that this is a historical artefact, from a time where CodePipeline was not capable of sourcing a particular commit hash, so there was no way to actually run a pipeline with a non-HEAD commit - or even a commit that wasn't latest@main, because generally it's inadvisable to change the source branch of the pipeline, as that's a permanent configuration difference that does class as a form of infra drift.

Nowadays (and as of [November 2023](https://aws.amazon.com/about-aws/whats-new/2023/11/aws-codepipeline-pipeline-execution-source-revision-overrides/)) you can use the `source revision override` feature to run CodePipeline on an arbitrary commit hash. Given our main concern was facilitating quick rollbacks or checkouts to other commits if needed (e.g., in the case of an emergency), this feature does largely render our old tag-based strategy redundant, and at this point it just serves to confuse people. 

Corresponding PRs will be created in Admin, API, Govuk, and Utils.

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
