### PR TITLE
EAS-2173: Utils: Add constants for elevation admin action type

### DIFF
--- a/emergency_alerts_utils/admin_action.py
+++ b/emergency_alerts_utils/admin_action.py
@@ -2,11 +2,13 @@
 ADMIN_INVITE_USER = "invite_user"
 ADMIN_EDIT_PERMISSIONS = "edit_permissions"  # Only if adding permissions, removal does not need approval
 ADMIN_CREATE_API_KEY = "create_api_key"
+ADMIN_ELEVATE_USER = "elevate_platform_admin"  # To elevate the creator temporarily
 
 ADMIN_ACTION_LIST = [
     ADMIN_INVITE_USER,
     ADMIN_EDIT_PERMISSIONS,
     ADMIN_CREATE_API_KEY,
+    ADMIN_ELEVATE_USER,
 ]
 
 ADMIN_STATUS_PENDING = "pending"

--- a/emergency_alerts_utils/admin_action.py
+++ b/emergency_alerts_utils/admin_action.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 # Tasks which require another platform admin to approve before being actioned
 ADMIN_INVITE_USER = "invite_user"
 ADMIN_EDIT_PERMISSIONS = "edit_permissions"  # Only if adding permissions, removal does not need approval
@@ -25,3 +27,8 @@ ADMIN_STATUS_LIST = [
 
 # Permissions which require approval from an additional admin before being added
 ADMIN_SENSITIVE_PERMISSIONS = ["create_broadcasts", "approve_broadcasts"]
+
+# How long elevation requests (AdminAction) can exist before automatically invalidating
+ADMIN_ELEVATION_ACTION_TIMEOUT = timedelta(hours=2)
+# How long an approved elevation can remain unredeemed for before the next login doesn't grant platform admin
+ADMIN_ELEVATION_REDEMPTION_TIMEOUT = timedelta(hours=24)


### PR DESCRIPTION
As title, this adds a few new constants as per the ticket. We'll have a new action type (thus allowing another admin to approve) and some associated timeouts.

This will be required for the API (and soon admin) CI to succeed so I thought I'd get it in early.

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
