### PR TITLE
Run PR checks on the branch even when the corresponding PR is in draft

### DIFF
--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -5,6 +5,11 @@ env:
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
 

--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -13,6 +13,8 @@ on:
     branches:
       - main
 
+# Sneaky PR test - temporary; remove when we know that the PR checks actually run
+
 jobs:
   run-pr-checks:
     runs-on: ubuntu-24.04

--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -13,8 +13,6 @@ on:
     branches:
       - main
 
-# Sneaky PR test - temporary; remove when we know that the PR checks actually run
-
 jobs:
   run-pr-checks:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This PR adds the ability for PR checks to be run on pull requests to the main branch even when they are in a draft state. Currently, they only run when the PR is in a "Ready for review" state, which isn't very helpful in instances where you want an easy way of checking the build status of your work on the branch itself, without indicating to other people that you would like your PR to be reviewed. 

Corresponding PRs will be made for Utils, API, Admin, and gov.uk/alerts

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
