### PR TITLE
EAS-2602 + EAS-2603: Utils: Add constants used for XML generation

### DIFF
--- a/emergency_alerts_utils/xml/cap.py
+++ b/emergency_alerts_utils/xml/cap.py
@@ -111,3 +111,15 @@ def generate_cap_cancel_message(identifier, sent, references):
     xml_subelement(alert, "references", text=references_string)
 
     return alert
+
+
+def convert_utc_datetime_to_cap_standard_string(dt):
+    """
+    As defined in section 3.3.2 of
+    http://docs.oasis-open.org/emergency/cap/v1.2/CAP-v1.2-os.html
+    They define the standard "YYYY-MM-DDThh:mm:ssXzh:zm", where X is
+    `+` if the timezone is > UTC, otherwise `-`
+
+    No validation of the provided datetime is performed. It must be in UTC.
+    """
+    return f"{dt.strftime('%Y-%m-%dT%H:%M:%S')}-00:00"

--- a/emergency_alerts_utils/xml/common.py
+++ b/emergency_alerts_utils/xml/common.py
@@ -25,6 +25,8 @@ ALLOWED_CHANNELS = [TEST_CHANNEL, OPERATOR_CHANNEL, SEVERE_CHANNEL, GOVERNMENT_C
 
 SENDER = "broadcasts@notifications.service.gov.uk"
 
+HEADLINE = "GOV.UK Emergency Alert"
+
 
 def digitally_sign(xml, key, cert):
     """


### PR DESCRIPTION
Migrated from API to be used in admin too.

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
