### PR TITLE
EAS-2653: Utils: Add out of hours admin constants and enhance ZenDesk client to edit

### DIFF
--- a/emergency_alerts_utils/admin_action.py
+++ b/emergency_alerts_utils/admin_action.py
@@ -32,3 +32,13 @@ ADMIN_SENSITIVE_PERMISSIONS = ["create_broadcasts", "approve_broadcasts"]
 ADMIN_ELEVATION_ACTION_TIMEOUT = timedelta(hours=2)
 # How long an approved elevation can remain unredeemed for before the next login doesn't grant platform admin
 ADMIN_ELEVATION_REDEMPTION_TIMEOUT = timedelta(hours=24)
+
+ADMIN_ZENDESK_TICKET_TITLE_PREFIX = "Admin Activity Out of Hours"
+# Treat outside of 8am - 6pm as outside office hours:
+ADMIN_ZENDESK_OFFICE_HOURS_START = "8"
+ADMIN_ZENDESK_OFFICE_HOURS_END = "6"
+
+# What each event should be as a priority in ZenDesk when it occurs out of hours:
+ADMIN_ZENDESK_PRIORITY_REQUEST = "low"
+ADMIN_ZENDESK_PRIORITY_APPROVE = "normal"
+ADMIN_ZENDESK_PRIORITY_ELEVATED = "urgent"

--- a/emergency_alerts_utils/admin_action.py
+++ b/emergency_alerts_utils/admin_action.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from zoneinfo import ZoneInfo
 
 # Tasks which require another platform admin to approve before being actioned
 ADMIN_INVITE_USER = "invite_user"
@@ -35,8 +36,9 @@ ADMIN_ELEVATION_REDEMPTION_TIMEOUT = timedelta(hours=24)
 
 ADMIN_ZENDESK_TICKET_TITLE_PREFIX = "Admin Activity Out of Hours"
 # Treat outside of 8am - 6pm as outside office hours:
-ADMIN_ZENDESK_OFFICE_HOURS_START = "8"
-ADMIN_ZENDESK_OFFICE_HOURS_END = "6"
+ADMIN_ZENDESK_OFFICE_HOURS_START = 8
+ADMIN_ZENDESK_OFFICE_HOURS_END = 18
+ADMIN_ZENDESK_OFFICE_HOURS_TIMEZONE = ZoneInfo("Europe/London")
 
 # What each event should be as a priority in ZenDesk when it occurs out of hours:
 ADMIN_ZENDESK_PRIORITY_REQUEST = "low"

--- a/emergency_alerts_utils/admin_action.py
+++ b/emergency_alerts_utils/admin_action.py
@@ -34,7 +34,7 @@ ADMIN_ELEVATION_ACTION_TIMEOUT = timedelta(hours=2)
 # How long an approved elevation can remain unredeemed for before the next login doesn't grant platform admin
 ADMIN_ELEVATION_REDEMPTION_TIMEOUT = timedelta(hours=24)
 
-ADMIN_ZENDESK_TICKET_TITLE_PREFIX = "Admin Activity Out of Hours"
+ADMIN_ZENDESK_TICKET_TITLE_PREFIX = "Out of Hours Admin Activity"
 # Treat outside of 8am - 6pm as outside office hours:
 ADMIN_ZENDESK_OFFICE_HOURS_START = 8
 ADMIN_ZENDESK_OFFICE_HOURS_END = 18

--- a/emergency_alerts_utils/clients/zendesk/zendesk_client.py
+++ b/emergency_alerts_utils/clients/zendesk/zendesk_client.py
@@ -43,7 +43,7 @@ class ZendeskClient:
         Get a ticket ID if there's an open ticket referring to admin activity out of hours.
         Note that the email is expected to always be concerning the invidivual *becoming* an admin, not any approver.
         """
-        params = {"query": f"type:ticket status:open {ADMIN_ZENDESK_TICKET_TITLE_PREFIX} requester:{email}"}
+        params = {"query": f"type:ticket status:new status:open {ADMIN_ZENDESK_TICKET_TITLE_PREFIX} requester:{email}"}
         response = requests.get(self.ZENDESK_SEARCH_TICKETS_URL, params=params, headers=self.headers())
         json = response.json()
 
@@ -63,7 +63,7 @@ class ZendeskClient:
 
         response = requests.put(
             self.ZENDESK_TICKET_ID_URL_PREFIX + str(ticket_id),
-            json={"priority": priority, "comment": {"body": comment}},
+            json={"ticket": {"priority": priority, "comment": {"body": comment}}},
             headers=self.headers(),
         )
         return response

--- a/emergency_alerts_utils/clients/zendesk/zendesk_client.py
+++ b/emergency_alerts_utils/clients/zendesk/zendesk_client.py
@@ -118,6 +118,7 @@ class EASSupportTicket:
         service_id=None,
         email_ccs=None,
         message_as_html=False,
+        custom_priority=None,
     ):
         self.subject = subject
         self.message = message
@@ -133,6 +134,7 @@ class EASSupportTicket:
         self.service_id = service_id
         self.email_ccs = email_ccs
         self.message_as_html = message_as_html
+        self.custom_priority = custom_priority
 
     @property
     def request_data(self):
@@ -146,7 +148,7 @@ class EASSupportTicket:
                 "group_id": self.EAS_GROUP_ID,
                 "organization_id": self.EAS_ORG_ID,
                 "ticket_form_id": self.EAS_TICKET_FORM_ID,
-                "priority": self.PRIORITY_URGENT if self.p1 else self.PRIORITY_NORMAL,
+                "priority": self.custom_priority or (self.PRIORITY_URGENT if self.p1 else self.PRIORITY_NORMAL),
                 "tags": self.TAGS_P1 if self.p1 else self.TAGS_P2,
                 "type": self.ticket_type,
                 "custom_fields": self._get_custom_fields(),

--- a/emergency_alerts_utils/clients/zendesk/zendesk_client.py
+++ b/emergency_alerts_utils/clients/zendesk/zendesk_client.py
@@ -52,7 +52,7 @@ class ZendeskClient:
 
         return json["results"][0]["id"]
 
-    def update_ticket_priority(self, ticket_id: int, priority: str):
+    def update_ticket_priority_with_comment(self, ticket_id: int, priority: str, comment: str):
         if priority not in [
             EASSupportTicket.PRIORITY_LOW,
             EASSupportTicket.PRIORITY_NORMAL,
@@ -62,7 +62,9 @@ class ZendeskClient:
             raise ZendeskError(f"Priority {priority} is unknown")
 
         response = requests.put(
-            self.ZENDESK_TICKET_ID_URL_PREFIX + str(ticket_id), json={"priority": priority}, headers=self.headers()
+            self.ZENDESK_TICKET_ID_URL_PREFIX + str(ticket_id),
+            json={"priority": priority, "comment": {"body": comment}},
+            headers=self.headers(),
         )
         return response
 

--- a/emergency_alerts_utils/clients/zendesk/zendesk_client.py
+++ b/emergency_alerts_utils/clients/zendesk/zendesk_client.py
@@ -93,7 +93,7 @@ class EASSupportTicket:
     # All tickets using visual formatting to Slack/Email recipients must have this tag
     BASE_TAGS = ["emergency_alerts_new_alarm"]
     TAGS_P2 = BASE_TAGS + [TARGET_TAGS["SLACK_DEV"], TARGET_TAGS["EMAIL_GROUP_MAILBOX"]]
-    TAGS_P1 = TAGS_P2 + [TARGET_TAGS["PAGERDUTY"]]
+    TAGS_P1 = TAGS_P2 + [TARGET_TAGS["PAGERDUTY"], TARGET_TAGS["SLACK_SUPPORT"]]
 
     TYPE_PROBLEM = "problem"
     TYPE_INCIDENT = "incident"

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -253,11 +253,11 @@ def test_zendesk_client_queries_admin_ticket_id(zendesk_client, rmock):
         + "?query=type%3Aticket+status%3Anew+status%3Aopen+Out+of+Hours+Admin+Activity+"
         + "requester%3Atest.user%40digital.cabinet-office.gov.uk",
         status_code=200,
-        json={"count": 1, "results": [{"id": 1234}]},
+        json={"count": 2, "results": [{"id": 1234, "status": "closed"}, {"id": 5678, "status": "new"}]},
     )
 
     ticket_id = zendesk_client.get_open_admin_zendesk_ticket_id_for_email("test.user@digital.cabinet-office.gov.uk")
-    assert ticket_id == 1234
+    assert ticket_id == 5678
 
 
 def test_zendesk_client_returns_none_for_no_admin_activity_ticket(zendesk_client, rmock):

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -250,7 +250,7 @@ def test_zendesk_client_queries_admin_ticket_id(zendesk_client, rmock):
     rmock.request(
         "GET",
         ZendeskClient.ZENDESK_SEARCH_TICKETS_URL
-        + "?query=type%3Aticket+status%3Aopen+Admin+Activity+Out+of+Hours+"
+        + "?query=type%3Aticket+status%3Anew+status%3Aopen+Out+of+Hours+Admin+Activity+"
         + "requester%3Atest.user%40digital.cabinet-office.gov.uk",
         status_code=200,
         json={"count": 1, "results": [{"id": 1234}]},
@@ -264,7 +264,7 @@ def test_zendesk_client_returns_none_for_no_admin_activity_ticket(zendesk_client
     rmock.request(
         "GET",
         ZendeskClient.ZENDESK_SEARCH_TICKETS_URL
-        + "?query=type%3Aticket+status%3Aopen+Admin+Activity+Out+of+Hours+"
+        + "?query=type%3Aticket+status%3Anew+status%3Aopen+Out+of+Hours+Admin+Activity+"
         + "requester%3Atest.user%40digital.cabinet-office.gov.uk",
         status_code=200,
         json={"count": 0, "results": []},
@@ -284,4 +284,4 @@ def test_zendesk_client_puts_update_to_ticket_priority(zendesk_client, rmock):
     zendesk_client.update_ticket_priority_with_comment(1234, "urgent", "comment")
 
     last_request = adapter.last_request.json()
-    assert last_request == {"priority": "urgent", "comment": {"body": "comment"}}
+    assert last_request == {"ticket": {"priority": "urgent", "comment": {"body": "comment"}}}

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -91,6 +91,20 @@ def test_zendesk_client_send_ticket_to_zendesk_error(zendesk_client, app, mocker
             "urgent",
             True,
         ),
+        (
+            {
+                "p1": True,
+                "custom_priority": "low",
+            },
+            [
+                "emergency_alerts_new_alarm",
+                "emergency_alerts_send_slack_dev",
+                "emergency_alerts_send_email_project",
+                "emergency_alerts_send_pagerduty",
+            ],
+            "low",  # Even though P1 is true, we should use the custom_priority
+            True,
+        ),
     ),
 )
 def test_eas_support_ticket_request_data(p1_arg, expected_tags, expected_priority, is_alarm_tag_expected):

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -261,11 +261,13 @@ def test_zendesk_client_returns_none_for_no_admin_activity_ticket(zendesk_client
 
 
 def test_zendesk_client_puts_update_to_ticket_priority(zendesk_client, rmock):
-    rmock.request(
+    adapter = rmock.request(
         "PUT",
         ZendeskClient.ZENDESK_TICKET_ID_URL_PREFIX + "1234",
         status_code=200,
         json={"ticket": {"id": 1234}},
     )
+    zendesk_client.update_ticket_priority_with_comment(1234, "urgent", "comment")
 
-    zendesk_client.update_ticket_priority(1234, "urgent")
+    last_request = adapter.last_request.json()
+    assert last_request == {"priority": "urgent", "comment": {"body": "comment"}}

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -87,6 +87,7 @@ def test_zendesk_client_send_ticket_to_zendesk_error(zendesk_client, app, mocker
                 "emergency_alerts_send_slack_dev",
                 "emergency_alerts_send_email_project",
                 "emergency_alerts_send_pagerduty",
+                "emergency_alerts_send_slack_support",
             ],
             "urgent",
             True,
@@ -101,6 +102,7 @@ def test_zendesk_client_send_ticket_to_zendesk_error(zendesk_client, app, mocker
                 "emergency_alerts_send_slack_dev",
                 "emergency_alerts_send_email_project",
                 "emergency_alerts_send_pagerduty",
+                "emergency_alerts_send_slack_support",
             ],
             "low",  # Even though P1 is true, we should use the custom_priority
             True,


### PR DESCRIPTION
As title, we now have some new constants defining 'out of hours' for admin elevation-related requests. We also enhance the ZenDesk client to be able to search for existing tickets referencing them and provide a method to edit the priority of said existing ticket. Since the intention is to go to PagerDuty while having different priorities I've also introduced a `custom_priority` field so we can still use `P1=True`.

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
