### PR TITLE
EAS-2692 Force Werkzeug version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "requests>=2.25.0",
         "python-json-logger>=3.2.0",
         "Flask>=3.0.2",
+        "Werkzeug>=3.1.3",
         "ordered-set>=4.1.0",
         "Jinja2>=2.11.3",
         "pyyaml>=6.0.1",


### PR DESCRIPTION
Werkzeug>=3.1.3

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
