### PR TITLE
EAS-2056: Utils: Add envsubst to container

### DIFF
--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -43,7 +43,8 @@ RUN apt-get install -y  \
     llvm \
     tk-dev \
     xz-utils \
-    zlib1g-dev
+    zlib1g-dev \
+    gettext
 
 RUN apt-get install -y apt-utils python-openssl libcurl4-openssl-dev python3-dev
 RUN apt-get install -y libssl-dev build-essential ca-certificates systemd-sysv


### PR DESCRIPTION
This is used in the Makefile(s) to embed the version information into version.py in the containers, so is needed in the base image when the sub project Dockerfile(s) are executing.

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
