### PR TITLE
Removing old CAP/IBAG doc links

### DIFF
--- a/emergency_alerts_utils/xml/cap.py
+++ b/emergency_alerts_utils/xml/cap.py
@@ -60,8 +60,6 @@ def generate_cap_alert(
 
     xml_subelement(info, "language", text=language)
     xml_subelement(info, "category", text="Safety")
-    # List of potential channel category values is defined in
-    # https://docs.google.com/spreadsheets/d/1NzaIa3BQoZzYVFXkhS2lSyGXLMRlI0Dg/edit#gid=316184578 for details
     cap_event = "RMT"
     if channel == OPERATOR_CHANNEL:
         cap_event = "OPR"

--- a/emergency_alerts_utils/xml/ibag.py
+++ b/emergency_alerts_utils/xml/ibag.py
@@ -77,8 +77,6 @@ def generate_ibag_alert(
         text=str(len(description.encode("utf-8"))),
     )
     xml_subelement(info, "IBAG_text_alert_message", text=description)
-    # List of potential channel category values is defined in
-    # https://docs.google.com/spreadsheets/d/1UKi18SpfIgaRhmD6iVGaItY-E3MJkxbB/edit#gid=2013248044
     IBAG_channel_category = "4380-CAT5-ENGLISH"
     if channel == OPERATOR_CHANNEL:
         IBAG_channel_category = "4382-CAT7-ENGLISH"


### PR DESCRIPTION
Removing links to old CAP/IBAG documentation, which I don't believe we use anymore.

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
