### PR TITLE
EAS-2956: Utils: Restrict PR CI permissions to read

### DIFF
--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -1,5 +1,8 @@
 name: on-pr-into-main
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: 3.12
 


### PR DESCRIPTION
Fixes https://github.com/alphagov/emergency-alerts-utils/security/code-scanning/1

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
