### PR TITLE
Adjusts CAP XML generation

### DIFF
--- a/emergency_alerts_utils/xml/broadcast.py
+++ b/emergency_alerts_utils/xml/broadcast.py
@@ -81,7 +81,7 @@ def generate_xml_body(event, signing_enabled=False, signing_key=None, signing_ce
                 channel=channel,
                 web=event.get("web"),
                 sender=event.get("sender"),
-                sender_name=event.get("sender_name")
+                sender_name=event.get("sender_name"),
             )
 
     elif message_type == CANCEL_MESSAGE_TYPE:
@@ -94,10 +94,7 @@ def generate_xml_body(event, signing_enabled=False, signing_key=None, signing_ce
             )
         else:
             xml = generate_cap_cancel_message(
-                identifier=identifier,
-                references=event["references"],
-                sent=event["sent"],
-                sender=event.get("sender")
+                identifier=identifier, references=event["references"], sent=event["sent"], sender=event.get("sender")
             )
 
     if signing_enabled:

--- a/emergency_alerts_utils/xml/broadcast.py
+++ b/emergency_alerts_utils/xml/broadcast.py
@@ -80,6 +80,8 @@ def generate_xml_body(event, signing_enabled=False, signing_key=None, signing_ce
                 language=event["language"],
                 channel=channel,
                 web=event.get("web"),
+                sender=event.get("sender"),
+                sender_name=event.get("sender_name")
             )
 
     elif message_type == CANCEL_MESSAGE_TYPE:
@@ -95,6 +97,7 @@ def generate_xml_body(event, signing_enabled=False, signing_key=None, signing_ce
                 identifier=identifier,
                 references=event["references"],
                 sent=event["sent"],
+                sender=event.get("sender")
             )
 
     if signing_enabled:

--- a/emergency_alerts_utils/xml/cap.py
+++ b/emergency_alerts_utils/xml/cap.py
@@ -32,7 +32,9 @@ def generate_cap_link_test(
     return alert
 
 
-def generate_cap_alert(identifier, headline, description, areas, sent, expires, language, channel, web=None):
+def generate_cap_alert(
+    identifier, headline, description, areas, sent, expires, language, channel, web=None, sender=None, sender_name=None
+):
     alert = ET.Element(
         "alert",
         attrib={
@@ -41,7 +43,7 @@ def generate_cap_alert(identifier, headline, description, areas, sent, expires, 
     )
 
     xml_subelement(alert, "identifier", text=identifier)
-    xml_subelement(alert, "sender", text=SENDER)
+    xml_subelement(alert, "sender", text=sender or SENDER)
     xml_subelement(alert, "sent", text=sent)
     xml_subelement(alert, "status", text="Actual")
     xml_subelement(alert, "msgType", text="Alert")
@@ -63,7 +65,7 @@ def generate_cap_alert(identifier, headline, description, areas, sent, expires, 
     xml_subelement(info, "severity", text="Severe")
     xml_subelement(info, "certainty", text="Likely")
     xml_subelement(info, "expires", text=expires)
-    xml_subelement(info, "senderName", text="GOV.UK Emergency Alerts")
+    xml_subelement(info, "senderName", text=sender_name or "GOV.UK Emergency Alerts")
     xml_subelement(info, "headline", text=headline)
     xml_subelement(info, "description", text=description)
 
@@ -89,7 +91,7 @@ def generate_cap_alert(identifier, headline, description, areas, sent, expires, 
     return alert
 
 
-def generate_cap_cancel_message(identifier, sent, references):
+def generate_cap_cancel_message(identifier, sent, references, sender=None):
     alert = ET.Element(
         "alert",
         attrib={
@@ -97,11 +99,11 @@ def generate_cap_cancel_message(identifier, sent, references):
         },
     )
 
-    references_list = [f"{SENDER},{ref['message_id']},{ref['sent']}" for ref in references]
+    references_list = [f"{sender or SENDER},{ref['message_id']},{ref['sent']}" for ref in references]
     references_string = " ".join(references_list)
 
     xml_subelement(alert, "identifier", text=identifier)
-    xml_subelement(alert, "sender", text=SENDER)
+    xml_subelement(alert, "sender", text=sender or SENDER)
     xml_subelement(alert, "sent", text=sent)
     xml_subelement(alert, "status", text="Actual")
     xml_subelement(alert, "msgType", text="Cancel")

--- a/emergency_alerts_utils/xml/cap.py
+++ b/emergency_alerts_utils/xml/cap.py
@@ -73,12 +73,18 @@ def generate_cap_alert(identifier, headline, description, areas, sent, expires, 
     for i, a in enumerate(areas):
         area = xml_subelement(info, "area")
 
-        xml_subelement(area, "areaDesc", text="area-{}".format(i + 1))
-        xml_subelement(
-            area,
-            "polygon",
-            text=" ".join(["{},{}".format(pair[0], pair[1]) for pair in a["polygon"]]),
-        )
+        # Uses area description if provided, else default to "area-{n}""
+        area_desc = a.get("description", "area-{}".format(i + 1))
+        xml_subelement(area, "areaDesc", text=area_desc)
+
+        # Area can have one or more polygons
+        polygons = a.get("polygons") or [a["polygon"]]
+        for polygon in polygons:
+            xml_subelement(
+                area,
+                "polygon",
+                text=" ".join(["{},{}".format(pair[0], pair[1]) for pair in polygon]),
+            )
 
     return alert
 


### PR DESCRIPTION
This PR is a pre-requisite for the CAP XML changes for Public Alerts feed, and consists of the following changes:
- sender and sender_name sourced from event object, to be used in CAP XML for elements, `sender` and `senderName` respectively (instead of just being set to `SENDER` value or default sender name value, though these remain the defaults)
- `areaDesc` element set if provided, else remains as the default `area-n`
- `polygon` elements combined into one area, if provided in one area object

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
