### PR TITLE
EAS-3031: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,3 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-      pip-updates:
-        applies-to: version-updates
-        patterns:
-          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,12 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+          - version-update:semver-patch
     groups:
       pip-security:
         applies-to: security-updates


### PR DESCRIPTION


---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
