### PR TITLE
EAS-2972: Work around an infinite loop if no messages need to be fetched

### DIFF
--- a/emergency_alerts_utils/dramatiq/broker.py
+++ b/emergency_alerts_utils/dramatiq/broker.py
@@ -1,4 +1,5 @@
 from base64 import b64decode
+from time import sleep
 
 from dramatiq.message import Message
 from dramatiq_sqs.broker import SQSBroker, SQSConsumer, _SQSMessage
@@ -17,12 +18,15 @@ class EasSqsConsumer(SQSConsumer):
         The overridden method does not provide a way to adjust the params to the SQS receive call.
         Namely, we'd rather have the attributes/metadata about messages which can be used by our
         retry middleware (e.g. ApproximateReceiveCount) and logged.
+
+        It also works around an infinite spin loop while enough messages are in-memory by sleeping
+        before returning None.
         """
 
         kw = {
             "MaxNumberOfMessages": self.prefetch,
             "WaitTimeSeconds": self.wait_time_seconds,
-            "MessageSystemAttributeNames": ["All"],  # The only part of this method that's changed
+            "MessageSystemAttributeNames": ["All"],  # The only extra kw
         }
         if self.visibility_timeout is not None:
             kw["VisibilityTimeout"] = self.visibility_timeout
@@ -43,6 +47,13 @@ class EasSqsConsumer(SQSConsumer):
             try:
                 return self.messages.popleft()
             except IndexError:
+                # If we return None this method will be called again right away, leading to a loop
+                # if not self.message_refc < self.prefetch (i.e. we have enough messages).
+                # Thus we should wait a bit to let the CPU not burn cycles needlessly while
+                # competing against other thread(s) that are trying to process messages.
+                if not self.message_refc < self.prefetch:
+                    sleep(0.1)
+
                 return None
 
     def nack(self, message: _SQSMessage):


### PR DESCRIPTION
This works around returning None in an infinite loop (as _ConsumerThread in Dramatiq calls in a loop) as quickly as possible while messages are processing. Other brokers (e.g. Redis: https://github.com/Bogdanp/dramatiq/blob/0ebf911d3fc24ff1284871692589ec4bbc307031/dramatiq/brokers/redis.py#L370-L373) do a sleep before returning None so that's what I do here.

I should note that 100ms is an arbitrary time to sleep, but such an amount of time really doesn't matter for our needs - we just need to break the CPU heavy loop.
