### PR TITLE
chore: Bump urllib3 to 2.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pytest-profiling==1.8.1
 pytest-xdist==3.8.0
 pytest==9.0.3
 requests-mock==1.12.1
-urllib3==2.6.3
+urllib3==2.7.0


### PR DESCRIPTION


---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
