### PR TITLE
EAS-2949 Build EICAR signature into docker image to test threat monitoring

### DIFF
--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -110,6 +110,7 @@ RUN python$PYTHON_VERSION -m venv $VENV_UTILS
 # Build emergency-alerts-utils
 COPY --chown=easuser:easuser . $DIR_UTILS
 RUN cd $DIR_UTILS && . $VENV_UTILS/bin/activate && make bootstrap
+RUN printf '%s' 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*' > $DIR_UTILS/eicar.txt
 
 # Remove our .git folder, we don't need it once the build is complete
 RUN rm -rf $DIR_UTILS/.git


### PR DESCRIPTION
This deployment should persist in the /emergency-alerts-utils build long enough to trigger a response from the AWS threat monitoring mechanisms. Once detection of the EICAR test file has triggered an alert, it should be removed before a build of API, Admin & GovUK images can incorporate the alerting image into their builds.

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
