### PR TITLE
refactor: Unicode CodePoint eval

### DIFF
--- a/emergency_alerts_utils/sanitise_text.py
+++ b/emergency_alerts_utils/sanitise_text.py
@@ -46,7 +46,7 @@ class SanitiseText:
         # lets just make sure we aren't evaling anything weird
         if not set(codepoint) <= set("0123456789ABCDEF") or not len(codepoint) == 4:
             raise ValueError(f"{codepoint} is not a valid unicode codepoint")
-        return eval(f'"\\u{codepoint}"')
+        return chr(int(codepoint, 16))
 
     @classmethod
     def downgrade_character(cls, c):


### PR DESCRIPTION
Tweaks the `get_unicode_char_from_codepoint` method of `SanitiseText` to use `chr` instead of an `eval`, since SAST tools will indiscriminately flag an `eval` as a critical issue (ignoring the validation we have around it).

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
