### PR TITLE
fix: Add `apt-get upgrade` to base image build

### DIFF
--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -52,6 +52,8 @@ RUN apt-get update && \
     apt-get clean && \
     update-ca-certificates
 
+RUN apt-get update && apt-get upgrade -y
+
 # Install commonly used tools, python related pre-reqs, and OS tools
 # We need to have ca-certificates installed before this point
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Adds `apt-get upgrade -y` to the base image build. To be honest, I thought we already did this! I don't see a problem with this - given we already use the mutable tag `ubuntu:24.04`, this isn't doing any further damage to immutability and is more secure.

Side point: the `apt-get upgrade` goes after the bits around `ca-certificates`, but then before anything else. This is a deliberate decision, which is explained here: https://github.com/alphagov/emergency-alerts-utils/pull/156

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
