### PR TITLE
EAS-3054 Add geocode element(s) to iBAG area

### DIFF
--- a/emergency_alerts_utils/xml/ibag.py
+++ b/emergency_alerts_utils/xml/ibag.py
@@ -95,6 +95,8 @@ def generate_ibag_alert(
             "IBAG_polygon",
             text=" ".join(["{},{}".format(pair[0], pair[1]) for pair in a["polygon"]]),
         )
+        for geocode in a.get("geocodes", []):
+            xml_subelement(area, "IBAG_geocode", text=geocode)
 
     xml_subelement(alert, "IBAG_Digital_Signature", text="")
 

--- a/emergency_alerts_utils/xml/ibag.py
+++ b/emergency_alerts_utils/xml/ibag.py
@@ -90,11 +90,12 @@ def generate_ibag_alert(
         area = xml_subelement(info, "IBAG_Alert_Area")
 
         xml_subelement(area, "IBAG_area_description", text="area-{}".format(i + 1))
-        xml_subelement(
-            area,
-            "IBAG_polygon",
-            text=" ".join(["{},{}".format(pair[0], pair[1]) for pair in a["polygon"]]),
-        )
+        if polygon := a.get("polygon", []):
+            xml_subelement(
+                area,
+                "IBAG_polygon",
+                text=" ".join(["{},{}".format(pair[0], pair[1]) for pair in polygon]),
+            )
         for geocode in a.get("geocodes", []):
             xml_subelement(area, "IBAG_geocode", text=geocode)
 

--- a/tests/xml/test_ibag.py
+++ b/tests/xml/test_ibag.py
@@ -71,6 +71,7 @@ def test_ibag_alert_creation(channel, expected_IBAG_channel_category):
                 [51.74, -1.2],
                 [51.12, -1.2],
             ],
+            "geocodes": ["E07000008", "E07000009"],
         }
     ]
 
@@ -165,6 +166,18 @@ def test_ibag_alert_creation(channel, expected_IBAG_channel_category):
         "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_Alert_Area[1]/ibag:IBAG_polygon//text()",
         "ibag",
     ) == ["51.12,-1.2 51.12,1.2 51.74,1.2 51.74,-1.2 51.12,-1.2"]
+
+    assert xml_path(
+        alert_body,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_Alert_Area[1]/ibag:IBAG_geocode[1]//text()",
+        "ibag",
+    ) == ["E07000008"]
+
+    assert xml_path(
+        alert_body,
+        "/ibag:IBAG_Alert_Attributes/ibag:IBAG_alert_info/ibag:IBAG_Alert_Area[1]/ibag:IBAG_geocode[2]//text()",
+        "ibag",
+    ) == ["E07000009"]
 
     assert xml_path(
         alert_body,


### PR DESCRIPTION
An area definition may include one or more "geocode" string elements which are added as "IBAG_geocode" subelements of the "IBAG_Alert_Area" element.

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
