### PR TITLE
Remove unused utils venv

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+venv/
+dist/

--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -16,7 +16,6 @@ ENV HOST='hosted'
 
 # Virtual Envs
 ENV VENV_ROOT='/venv'
-ENV VENV_UTILS='/venv/emergency-alerts-utils'
 ENV VENV_API='/venv/emergency-alerts-api'
 ENV VENV_GOVUK='/venv/emergency-alerts-govuk'
 ENV VENV_ADMIN='/venv/emergency-alerts-admin'
@@ -103,15 +102,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -p).zip" -o 'aws
     ./aws/install && \
     rm -rf ./aws awscliv2.zip
 
-# Create a normal user and run all subsequent steps as them
+# Create a normal user and run all downstream containers as them
 RUN useradd -ms /bin/bash easuser && mkdir -p ${VENV_ROOT} ${DIR_EAS} && chown easuser:easuser ${VENV_ROOT} ${DIR_EAS}
 USER easuser
 
-RUN python$PYTHON_VERSION -m venv $VENV_UTILS
-
-# Build emergency-alerts-utils
 COPY --chown=easuser:easuser . $DIR_UTILS
-RUN cd $DIR_UTILS && . $VENV_UTILS/bin/activate && make bootstrap
-
-# Remove our .git folder, we don't need it once the build is complete
-RUN rm -rf $DIR_UTILS/.git


### PR DESCRIPTION
The base image build here copies in utils and then creates a venv and installs utils dependencies into it. The latter part is subtly wrong: workloads will create their own venv, and install utils from the sibling dir - thus any workloads will install utils dependencies again elsewhere.

In addition I've popped in a `.dockerignore` to remove `.git` from the build context entirely, let alone removing it in a subsequent layer.

This saves about 140mb:
<img width="1032" height="271" alt="image" src="https://github.com/user-attachments/assets/a4ffc76c-9c59-4a18-8a7c-b450ff3b4048" />

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
