### PR TITLE
EAS-3066: Don't error if ZenDesk API key is not configured

### DIFF
--- a/emergency_alerts_utils/clients/zendesk/zendesk_client.py
+++ b/emergency_alerts_utils/clients/zendesk/zendesk_client.py
@@ -23,10 +23,17 @@ class ZendeskClient:
     def init_app(self, app, *args, **kwargs):
         self.api_key = app.config.get("ZENDESK_API_KEY")
 
+        if self.api_key is None:
+            app.logger.warning("ZENDESK_API_KEY is empty - posting to ZenDesk will be unavailable")
+
     def headers(self):
         return {"Accept": "application/json", "Authorization": f"Basic {self.api_key}"}
 
     def send_ticket_to_zendesk(self, ticket):
+        if self.api_key is None:
+            current_app.logger.error("Skipping posting to ZenDesk because ZENDESK_API_KEY is empty")
+            return False
+
         response = requests.post(self.ZENDESK_TICKET_URL, json=ticket.request_data, headers=self.headers())
 
         if response.status_code != 201:
@@ -38,6 +45,7 @@ class ZendeskClient:
         ticket_id = response.json()["ticket"]["id"]
 
         current_app.logger.info(f"Zendesk create ticket {ticket_id} succeeded")
+        return ticket_id
 
     def get_open_admin_zendesk_ticket_id_for_email(self, email) -> Optional[int]:
         """

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -53,6 +53,18 @@ def test_zendesk_client_send_ticket_to_zendesk_error(zendesk_client, app, mocker
     mock_logger.assert_called_with("Zendesk create ticket request failed with 401 '{'foo': 'bar'}'")
 
 
+def test_zendesk_client_skips_send_if_no_api_key(zendesk_client, app, mocker, rmock):
+    del app.config["ZENDESK_API_KEY"]
+    zendesk_client.init_app(app)
+    mock_logger = mocker.patch.object(app.logger, "error")
+
+    ticket = EASSupportTicket("subject", "message", "incident")
+    zendesk_client.send_ticket_to_zendesk(ticket)
+
+    assert rmock.last_request is None
+    mock_logger.assert_called_once_with("Skipping posting to ZenDesk because ZENDESK_API_KEY is empty")
+
+
 @pytest.mark.parametrize(
     "p1_arg, expected_tags, expected_priority, is_alarm_tag_expected",
     (


### PR DESCRIPTION
As part of running functional tests in PRs (or locally) we won't have access to ZenDesk in that environment. This breaks the feedback form, and thus a relating functional test. E.g. https://github.com/alphagov/emergency-alerts-admin/actions/runs/26961174754#summary-79551593197 - top_rail_services.

Since this isn't critical functionality I log here if an API key isn't set and avoid contacting ZenDesk if so. Alternatively we could have a new env on admin that can disable invoking ZendeskClient at all?

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
