### PR TITLE
EAS-3112 Fix telnet vulnerability CVE-2026-32746

### DIFF
--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -81,6 +81,7 @@ RUN apt-get update && apt-get install -y \
     jq \
     curl \
     wget \
+    telnet \
     dnsutils && \
     apt-get upgrade -y && \
     # And cleanup the package caches

--- a/Dockerfile.eas-base
+++ b/Dockerfile.eas-base
@@ -52,10 +52,12 @@ RUN apt-get update && \
     apt-get clean && \
     update-ca-certificates
 
-RUN apt-get update && apt-get upgrade -y
-
 # Install commonly used tools, python related pre-reqs, and OS tools
-# We need to have ca-certificates installed before this point
+# We need to have ca-certificates installed before this point.
+# The upgrade is run *after* the install (in the same layer) so that
+# transitively-installed packages are patched to their latest security release.
+# Note: telnet (and its vulnerable inetutils-telnet dependency) is deliberately
+# not installed; use curl/nc for connectivity debugging instead.
 RUN apt-get update && apt-get install -y \
     build-essential \
     # Python build dependencies:
@@ -79,8 +81,8 @@ RUN apt-get update && apt-get install -y \
     jq \
     curl \
     wget \
-    telnet \
     dnsutils && \
+    apt-get upgrade -y && \
     # And cleanup the package caches
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 


### PR DESCRIPTION
Remove `telnet` to stop the installation of the vulnerable `inetutils-telnet` package.

Move the `apt-get upgrade` command so that transitively installed packages are upgraded after installation.

---

🚨⚠️ PLEASE NOTE ⚠️🚨

After merging changes into the main branch of the utils repository, the base image will automatically be rebuilt, but then every other application image will also need to be rebuilt across environments on top of that.
This is to identify any issues that may crop up across the application as a result of making changes to utils (e.g., bumping package versions) early on.
If this is not done, it can obfuscate the origin of an issue were it to show up later.
