### PR TITLE
Remove pip constraints: Periodiq no longer requires a pin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 
 .PHONY: bootstrap
 bootstrap:
-	pip3 install -r requirements.txt -c constraints.txt
+	pip3 install -r requirements.txt
 
 .PHONY: test
 test: ## Run tests

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,0 @@
-setuptools<82 # 82+ removes pkg_resources, which is needed by periodiq


### PR DESCRIPTION
This is a holdover from the first introduction of Dramatiq, and works around Periodiq running into a very recent breaking setuptools change at the time.

Now Periodiq has been updated this is no longer a problem. And this was cleaned up from workloads when using utils' for pip-tools resolution (e.g. https://github.com/alphagov/emergency-alerts-admin/pull/410).
